### PR TITLE
Add a quick & dirty dirtree resource type

### DIFF
--- a/lib/puppet/provider/dirtree/ruby.rb
+++ b/lib/puppet/provider/dirtree/ruby.rb
@@ -1,0 +1,19 @@
+Puppet::Type.type(:dirtree).provide(:ruby) do
+  desc 'Ruby provider for the dirtree type'
+
+  def exists?
+    File.directory? resource[:path]
+  end
+
+  def create
+    if resource[:parents]
+      FileUtils.mkdir_p resource[:path]
+    else
+      FileUtils.mkdir resource[:path]
+    end
+  end
+
+  def destroy
+    true
+  end
+end

--- a/lib/puppet/type/dirtree.rb
+++ b/lib/puppet/type/dirtree.rb
@@ -1,0 +1,32 @@
+Puppet::Type.newtype(:dirtree) do
+  desc "Ensure the presence of a directory structure on the client"
+
+  ensurable do
+    newvalue(:present) do
+      provider.create
+    end
+
+    newvalue(:absent) do
+      raise Puppet::ParseError, 'The dirtree type does not support removal. Use the File type.'
+    end
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'Just a name to identify this resource by.'
+  end
+
+  newparam(:path) do
+    desc 'The path of the directory'
+    validate do |value|
+      unless Puppet::Util.absolute_path?(value)
+        fail Puppet::Error, "Directory tree paths must be fully qualified, not '#{value}'"
+      end
+    end
+  end
+
+  newparam(:parents) do
+    desc 'Create parents recursively'
+    newvalues true, false
+    defaultto false
+  end
+end

--- a/tests/type.pp
+++ b/tests/type.pp
@@ -1,0 +1,21 @@
+$dirtree = dirtree($::rubysitedir)
+
+notify { $dirtree: }
+
+dirtree { 'a temp dir':
+  ensure  => present,
+  path    => '/tmp/foo/bar/baz',
+  parents => true,
+}
+
+dirtree { 'another temp dir with the same path':
+  ensure  => present,
+  path    => '/tmp/foo/bar/baz',
+}
+
+file { '/tmp/foo/bar/baz':
+  ensure => directory,
+  owner  => 'root',
+  group  => 'root',
+  mode   => '0755',
+}


### PR DESCRIPTION
This allows you to declare a resource type that simply ensures that a
directory exists on the client. You cannot manage permissions or
ownership or anything, that's what the file type is for. It's just for
those edge cases when you just need to make sure a directory exists and
you don't have the liberty of managing the full path.

@glarizza and @hunner I'd appreciate your thoughts on this idea. This came from conversation around https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/init.pp#L154-L157
