### PR TITLE
switch to metadata.json for meta data

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,7 +1,0 @@
-name    'AlexCline-dirtree'
-version '0.2.1'
-author 'Alex Cline <alex.cline@gmail.com>'
-license 'Apache License, Version 2.0'
-summary 'The dirtree function builds an array of directories from a full directory path or an array of full directory paths.  The array can then be used to ensure all the required directories in a path are managed by puppet.'
-description 'The dirtree function builds an array of directories from a full directory path or an array of full directory paths.  The array can then be used to ensure all the required directories in a path are managed by puppet.'
-project_page 'https://github.com/AlexCline/dirtree'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "AlexCline-dirtree",
+  "version": "0.2.1",
+  "author": "Alex Cline \u003calex.cline@gmail.com\u003e",
+  "license": "Apache License, Version 2.0",
+  "operatingsystem_support": [],
+  "project_page": "https://github.com/AlexCline/dirtree",
+  "requirements": [],
+  "source": "ssh://git@github.com/AlexCline/puppet-dirtree.git",
+  "summary": "The dirtree function builds an array of directories from a full directory path or an array of full directory paths.  The array can then be used to ensure all the required directories in a path are managed by puppet.",
+  "tags": [],
+  "dependencies": []
+}


### PR DESCRIPTION
The Modulefile information does not seem to the be parsed by the puppet module tool anymore. This patch simply moves information into the format of the metadata.json file.
